### PR TITLE
feat: add --fail flag and change "No issues found" into a log

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn add @dated/markdown-title-case
 ## Usage
 
 ```bash
-markdown-title-case PATH [--recursive] [--fix]
+markdown-title-case PATH [--recursive] [--fix] [--fail]
 ```
 
 ## Markers

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ class MarkdownTitleCaseCommand extends Command {
           process.exit(1)
         }
       } else {
-        this.warn('No Issues found!')
+        this.log('No Issues found!')
       }
     })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,11 @@ class MarkdownTitleCaseCommand extends Command {
       description: 'also traverse subfolders',
       char: 'r',
       default: false
+    }),
+    fail: flags.boolean({
+      description: 'set non-zero return code if issues were found.',
+      char: 'F',
+      default: false
     })
   }
 
@@ -68,6 +73,9 @@ class MarkdownTitleCaseCommand extends Command {
 
       if (issueCount) {
         this.warn(`Found ${issueCount} issues`)
+        if(flags.fail) {
+          process.exit(1)
+        }
       } else {
         this.warn('No Issues found!')
       }


### PR DESCRIPTION
Hi,

I'd like to use the script in some builds, but it is proving a little tricky because the script doesn't set non-zero return codes when issues were found. In this PR I am proposing a "--fail (-F)" flag, that will set the return code to 1 if issues were found, for easier shell scripting. Also, I turned the "No issues found" warning into a regular log message, which seems right - ofc. I can revert that unrelated change.

Please let me know what you think - I'd appreciate if you could consider this addition for a release.

Cheers,
Michael